### PR TITLE
Added TorchAvailable check to prevent crash on iPad Mini

### DIFF
--- a/Lamp/Lamp/Lamp.Plugin.iOS/LampImplementation.cs
+++ b/Lamp/Lamp/Lamp.Plugin.iOS/LampImplementation.cs
@@ -41,6 +41,11 @@ namespace Lamp.Plugin
             }
             else
             {
+				if (!captureDevice.TorchAvailable)
+				{
+					Debug.WriteLine("The torch is not available on this device (captureDevice.TorchAvailable is false)");
+					return;
+				}
                 if (captureDevice.TorchMode != AVCaptureTorchMode.On)
                 {
                     captureDevice.TorchMode = AVCaptureTorchMode.On;

--- a/Lamp/Lamp/Lamp.Plugin.iOSUnified/LampImplementation.cs
+++ b/Lamp/Lamp/Lamp.Plugin.iOSUnified/LampImplementation.cs
@@ -34,6 +34,11 @@ namespace Lamp.Plugin
           }
           else
           {
+			  if (!captureDevice.TorchAvailable)
+			  {
+				  Debug.WriteLine("The torch is not available on this device (captureDevice.TorchAvailable is false)");
+				  return;
+			  }
               if (captureDevice.TorchMode != AVCaptureTorchMode.On)
               {
                   captureDevice.TorchMode = AVCaptureTorchMode.On;


### PR DESCRIPTION
Hi Kym,

When using your plugin and running my app on an iPad Mini, the app was crashing out without any exception or info whatsoever. I traced it to the code setting the TorchMode to on. Adding a check for TorchAvailable first on that device solves the issue. Well, the app no longer crashes, but of course the lamp doesn't go on either! Anyway, I thought I'd share as it might come up for other users.

Thanks for creating the package, certainly saved me some time!

Cheers,

David
