### PR TITLE
Minor fixes to make the flashlight work on Samsung Galaxy XX

### DIFF
--- a/Lamp/Lamp/Lamp.Plugin.Android/LampImplementation.cs
+++ b/Lamp/Lamp/Lamp.Plugin.Android/LampImplementation.cs
@@ -59,9 +59,7 @@ namespace Lamp.Plugin
               p.FlashMode = flashMode;
               camera.SetParameters(p);
           }
-
-          camera.StartPreview();
-
+		
           // nexus 5 fix here: http://stackoverflow.com/questions/21417332/nexus-5-4-4-2-flashlight-led-not-turning-on
           try
           {
@@ -72,6 +70,8 @@ namespace Lamp.Plugin
               // Ignore
           }
 
+			//Changed order of SetPreviewTexture and StartPreview. It seems Samsung Galaxy XX puts the camera in bad otherwise.
+		  camera.StartPreview();
       }
 
 
@@ -105,6 +105,9 @@ namespace Lamp.Plugin
               p.FlashMode = flashMode;
               camera.SetParameters(p);
           }
+
+			//Some phones do not switch off flash, or behave badly when not preview is stopped.
+			camera.StopPreview ();
       }
   }
 }


### PR DESCRIPTION
Hello!

I discovered some problems with Samsung Galaxy S6. 

Here is the description:

Problem with Samsung Galaxy S6:
1. Turn on Lamp (works as expected)
2. Turn off Lamp (works as expected)
3. Turn on Lamp (does nothing, the flash is not lit)
4. Turn off Lamp:

var p = camera.GetParameters(); in TurnOff causes the following exception to be thrown:

at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in /Users/builder/data/lanes/3236/ee215fc9/source/mono/external/referencesource/mscorlib/system/runtime/exceptionservices/exceptionservicescommon.cs:143 
at Android.Runtime.JNIEnv.CallObjectMethod (IntPtr jobject, IntPtr jmethod) [0x00063] in /Users/builder/data/lanes/3236/ee215fc9/source/monodroid/src/Mono.Android/src/Runtime/JNIEnv.g.cs:178 
at Android.Hardware.Camera.GetParameters () [0x00043] in /Users/builder/data/lanes/3236/ee215fc9/source/monodroid/src/Mono.Android/platforms/android-23/src/generated/Android.Hardware.Camera.cs:4904 
at Lamp.Plugin.LampImplementation.TurnOff () [0x00037] in F:\Mobile Development\eSmart\RIK\RingeriksKraft\Lamp.Plugin.Android\LampImplementation.cs:98 
--- End of managed exception stack trace ---
java.lang.RuntimeException: getParameters failed (empty parameters)
at android.hardware.Camera.native_getParameters(Native Method)
at android.hardware.Camera.getParameters(Camera.java:1996)
at mono.android.view.View_OnClickListenerImplementor.n_onClick(Native Method)
at mono.android.view.View_OnClickListenerImplementor.onClick(View_OnClickListenerImplementor.java:29)
at android.view.View.performClick(View.java:5697)
at android.view.View$PerformClick.run(View.java:22526)
at android.os.Handler.handleCallback(Handler.java:739)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:158)
at android.app.ActivityThread.main(ActivityThread.java:7224)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)

Some documentation to hopfully shed some light on the problem.

http://stackoverflow.com/questions/21417332/nexus-5-4-4-2-flashlight-led-not-turning-on
http://stackoverflow.com/questions/6068803/how-to-turn-on-camera-flash-light-programmatically-in-android
http://stackoverflow.com/questions/14941625/correct-handling-of-exception-getparameters-failed-empty-parameters

Thank you for sharing your work!

Regards 
Øyvind Liland
