### PR TITLE
Fix "getParameters failed (empty parameters)" issue

### DIFF
--- a/Lamp/Lamp/Lamp.Plugin.Android/LampImplementation.cs
+++ b/Lamp/Lamp/Lamp.Plugin.Android/LampImplementation.cs
@@ -105,6 +105,12 @@ namespace Lamp.Plugin
               p.FlashMode = flashMode;
               camera.SetParameters(p);
           }
+          
+          // sstevan: Fix "getParameters failed (empty parameters)" issue
+          camera.StopPreview();
+          camera.Release();
+          camera = null;
+          
       }
   }
 }


### PR DESCRIPTION
Hello,

I had issues with existing patches as well. Thanks for a great job!

---

Not releasing Camera caused crash "getParameters failed (empty parameters)".
E.g. 

OnAppearing() {Lamp.Plugin.CrossLamp.Current.TurnOn()} 
OnDisappear() {Lamp.Plugin.CrossLamp.Current.TurnOff()}

The first time it will work ok but if you try to reinitialize page again it would crash.