### PR TITLE
[Android] Release camera when turning off flash to allow use of the camera elsewhere

### DIFF
--- a/Lamp/Lamp/Lamp.Plugin.Android/LampImplementation.cs
+++ b/Lamp/Lamp/Lamp.Plugin.Android/LampImplementation.cs
@@ -89,21 +89,31 @@ namespace Lamp.Plugin
               return;
           }
 
-          var p = camera.GetParameters();
-          var supportedFlashModes = p.SupportedFlashModes;
-
-          if (supportedFlashModes == null)
-              supportedFlashModes = new List<string>();
-
-          var flashMode = string.Empty;
-
-          if (supportedFlashModes.Contains(Android.Hardware.Camera.Parameters.FlashModeTorch))
-              flashMode = Android.Hardware.Camera.Parameters.FlashModeOff;
-
-          if (!string.IsNullOrEmpty(flashMode))
+          try
           {
-              p.FlashMode = flashMode;
-              camera.SetParameters(p);
+              var p = camera.GetParameters();
+              var supportedFlashModes = p.SupportedFlashModes;
+
+              if (supportedFlashModes == null)
+                  supportedFlashModes = new List<string>();
+
+              var flashMode = string.Empty;
+
+              if (supportedFlashModes.Contains(Android.Hardware.Camera.Parameters.FlashModeTorch))
+                  flashMode = Android.Hardware.Camera.Parameters.FlashModeOff;
+
+              if (!string.IsNullOrEmpty(flashMode))
+              {
+                  p.FlashMode = flashMode;
+                  camera.SetParameters(p);
+              } 
+          }
+          finally
+          {
+              camera?.StopPreview();
+              camera?.Release();
+              camera?.Dispose();
+              camera = null;
           }
       }
   }


### PR DESCRIPTION
If the flash light gets turned on/off in android, the current implementation keeps a "lock" on the camera.  If I go somewhere else in code and want to use the camera to take a picture, it locks up because it thinks the "Lamp Plugin" is still using it.

Now, when turning off the lamp, release the camera.